### PR TITLE
chore(dev): centralize development and CI tasks in just

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,11 @@ jobs:
       - name: Set up Rust toolchain
         run: rustup show
 
+      - name: Install just
+        uses: taiki-e/install-action@v2
+        with:
+          tool: just
+
       - name: Set up Rust cache
         uses: actions/cache@v5
         with:
@@ -36,10 +41,10 @@ jobs:
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock', 'rust-toolchain.toml') }}
 
       - name: Build
-        run: cargo build --locked --verbose
+        run: just build-ci
 
       - name: Run tests
-        run: cargo test --locked --verbose
+        run: just test-ci
 
   lint:
     name: Lint & Format
@@ -51,11 +56,16 @@ jobs:
       - name: Set up Rust toolchain
         run: rustup show
 
+      - name: Install just
+        uses: taiki-e/install-action@v2
+        with:
+          tool: just
+
       - name: Check Formatting
-        run: cargo fmt -- --check
+        run: just fmt-check
 
       - name: Run Clippy
-        run: cargo clippy --locked --all-targets --all-features -- -D warnings
+        run: just clippy-ci
 
   release-tooling:
     name: Release Tooling
@@ -66,27 +76,24 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Install just
+        uses: taiki-e/install-action@v2
+        with:
+          tool: just
+
       - name: Install git-cliff
         uses: taiki-e/install-action@v2
         with:
           tool: git-cliff
 
       - name: Verify changelog generation
-        run: |
-          git-cliff --config cliff.toml --unreleased --tag v999.999.999 > /tmp/generated-changelog.md
-          test -s /tmp/generated-changelog.md
+        run: just verify-changelog
 
       - name: Verify release note extraction
-        run: |
-          chmod +x scripts/extract-release-notes.sh
-          version=$(python -c "from pathlib import Path; import re; content = Path('Cargo.toml').read_text(); match = re.search(r'(?m)^version = \"([0-9]+\.[0-9]+\.[0-9]+)\"$', content); print(match.group(1))")
-          scripts/extract-release-notes.sh "v${version}" > /tmp/release-notes.md
-          test -s /tmp/release-notes.md
+        run: just extract-notes
 
       - name: Verify release PR metadata when version changes
-        run: |
-          chmod +x scripts/check-release-pr.sh scripts/extract-release-notes.sh
-          scripts/check-release-pr.sh "${{ github.event.pull_request.base.sha }}" "${{ github.sha }}"
+        run: just check-release-pr "${{ github.event.pull_request.base.sha }}" "${{ github.sha }}"
 
   check-release-pipeline:
     name: Check Release Pipeline
@@ -94,6 +101,11 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
+
+      - name: Install just
+        uses: taiki-e/install-action@v2
+        with:
+          tool: just
 
       - name: Read dist version
         id: dist-version
@@ -117,10 +129,7 @@ jobs:
 
       - name: Verify release.yml is up to date
         shell: bash
-        run: |
-          dist generate
-          git diff --exit-code .github/workflows/release.yml || \
-            (echo "release.yml has been manually edited. Run 'dist generate' to restore it." && exit 1)
+        run: just verify-release-yml
 
       - name: Verify built-in updater release artifacts
         shell: bash

--- a/README.md
+++ b/README.md
@@ -171,6 +171,16 @@ Patterns support `*` wildcards (e.g., `releases/*` matches `releases/v1.0`).
 
 Press `p` in the TUI to toggle visibility of protected branches.
 
+## Development
+
+Install [`just`](https://just.systems/) to use the development recipes:
+
+```bash
+cargo install just
+```
+
+Run `just` to list the available recipes and their requirements. Before pushing, run `just ci` to execute the formatting, lint, build, and test gates.
+
 ## Branch Naming
 
 cazdo extracts the **first sequence of digits** found in the branch name to use as the Work Item ID.

--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ Install [`just`](https://just.systems/) to use the development recipes:
 cargo install just
 ```
 
-Run `just` to list the available recipes and their requirements. Before pushing, run `just ci` to execute the formatting, lint, build, and test gates.
+Run `just` to list the available recipes and their requirements. Before pushing, run `just ci`; it composes the same formatting, lint, build, and test recipes invoked by CI.
 
 ## Branch Naming
 

--- a/justfile
+++ b/justfile
@@ -1,4 +1,4 @@
-current_tag := "v" + `id="$(cargo pkgid)"; printf '%s' "${id##*@}"`
+current_tag := "v" + `id="$(cargo pkgid)"; version="${id##*#}"; printf '%s' "${version##*@}"`
 
 # List available recipes.
 _default:

--- a/justfile
+++ b/justfile
@@ -1,0 +1,51 @@
+# List available recipes.
+_default:
+    @just --list
+
+# Build the project for local development.
+build:
+    cargo build
+
+# Run the test suite for local development.
+test:
+    cargo test
+
+# Run cazdo, passing any additional arguments to the binary.
+run *ARGS:
+    cargo run -- {{ ARGS }}
+
+# Format the codebase in place.
+fmt:
+    cargo fmt
+
+# Run Clippy across all targets and features.
+clippy:
+    cargo clippy --all-targets --all-features
+
+# Run the same formatting, lint, build, and test gates as CI.
+ci:
+    cargo fmt -- --check
+    cargo clippy --locked --all-targets --all-features -- -D warnings
+    cargo build --locked
+    cargo test --locked
+
+# Preview the changelog for unreleased changes (requires git-cliff).
+changelog:
+    git-cliff --config cliff.toml --unreleased
+
+# Prepare a release for VERSION without committing it (requires git-cliff).
+prepare-release VERSION:
+    scripts/prepare-release.sh {{ VERSION }}
+
+# Verify the generated release workflow (requires cargo-dist).
+verify-release-yml:
+    dist generate
+    git diff --exit-code .github/workflows/release.yml
+
+# Regenerate the README demo assets (requires vhs).
+demo:
+    scripts/render-demo.sh
+
+# Remove stale temporary VHS demo repositories.
+cleanup-demos:
+    scripts/cleanup-vhs-demo-repos.sh

--- a/justfile
+++ b/justfile
@@ -1,3 +1,5 @@
+current_tag := "v" + `python -c 'import tomllib; print(tomllib.load(open("Cargo.toml", "rb"))["package"]["version"])'`
+
 # List available recipes.
 _default:
     @just --list
@@ -23,10 +25,22 @@ clippy:
     cargo clippy --all-targets --all-features
 
 # Run the same formatting, lint, build, and test gates as CI.
-ci:
+ci: fmt-check clippy-ci build-ci test-ci
+
+# Check formatting.
+fmt-check:
     cargo fmt -- --check
+
+# Run strict Clippy checks.
+clippy-ci:
     cargo clippy --locked --all-targets --all-features -- -D warnings
+
+# Build with locked dependencies.
+build-ci:
     cargo build --locked
+
+# Test with locked dependencies.
+test-ci:
     cargo test --locked
 
 # Preview the changelog for unreleased changes (requires git-cliff).
@@ -41,6 +55,20 @@ prepare-release VERSION:
 verify-release-yml:
     dist generate
     git diff --exit-code .github/workflows/release.yml
+
+# Verify that unreleased changelog generation produces output (requires git-cliff).
+verify-changelog:
+    git-cliff --config cliff.toml --unreleased --tag v999.999.999 > /tmp/generated-changelog.md
+    test -s /tmp/generated-changelog.md
+
+# Extract release notes for TAG, defaulting to the current package version.
+extract-notes TAG=current_tag:
+    scripts/extract-release-notes.sh {{ quote(TAG) }} > /tmp/release-notes.md
+    test -s /tmp/release-notes.md
+
+# Verify release metadata when the package version changes.
+check-release-pr BASE HEAD:
+    scripts/check-release-pr.sh {{ quote(BASE) }} {{ quote(HEAD) }}
 
 # Regenerate the README demo assets (requires vhs).
 demo:

--- a/justfile
+++ b/justfile
@@ -1,4 +1,4 @@
-current_tag := "v" + `python -c 'import tomllib; print(tomllib.load(open("Cargo.toml", "rb"))["package"]["version"])'`
+current_tag := "v" + `id="$(cargo pkgid)"; printf '%s' "${id##*@}"`
 
 # List available recipes.
 _default:
@@ -49,12 +49,12 @@ changelog:
 
 # Prepare a release for VERSION without committing it (requires git-cliff).
 prepare-release VERSION:
-    scripts/prepare-release.sh {{ VERSION }}
+    scripts/prepare-release.sh {{ quote(VERSION) }}
 
 # Verify the generated release workflow (requires cargo-dist).
 verify-release-yml:
     dist generate
-    git diff --exit-code .github/workflows/release.yml
+    git diff --exit-code .github/workflows/release.yml || (echo "release.yml has been manually edited. Run 'dist generate' to restore it." && exit 1)
 
 # Verify that unreleased changelog generation produces output (requires git-cliff).
 verify-changelog:


### PR DESCRIPTION
chore(dev): add common just recipes
closes #104 

ci: invoke canonical just recipes
closes #105 